### PR TITLE
fix(rollup-config): delete output directory only on build

### DIFF
--- a/commonjs/index.js
+++ b/commonjs/index.js
@@ -239,6 +239,9 @@ function getRollupConfig(options) {
         ...getBuildPlugins(parsedOptions)
       ];
     });
+    rollupConfig[0].plugins.unshift(
+      cleaner(getPluginConfig('cleaner', parsedOptions))
+    );
   }
   return rollupConfig;
 }
@@ -259,7 +262,6 @@ function getBaseRollupConfig(options) {
       format: 'esm',
     },
     plugins: [
-      cleaner(getPluginConfig('cleaner', parsedOptions)),
       copy(getPluginConfig('copy', parsedOptions)),
       resolve(),
       babel(getPluginConfig('babel', parsedOptions))

--- a/src/rollup-config.mjs
+++ b/src/rollup-config.mjs
@@ -46,6 +46,9 @@ export function getRollupConfig(options) {
         ...getBuildPlugins(parsedOptions)
       ]
     });
+    rollupConfig[0].plugins.unshift(
+      cleaner(getPluginConfig('cleaner', parsedOptions))
+    );
   }
   return rollupConfig;
 }
@@ -66,7 +69,6 @@ export function getBaseRollupConfig(options) {
       format: 'esm',
     },
     plugins: [
-      cleaner(getPluginConfig('cleaner', parsedOptions)),
       copy(getPluginConfig('copy', parsedOptions)),
       resolve(),
       babel(getPluginConfig('babel', parsedOptions))


### PR DESCRIPTION
avoid deleting the output directory on serve mode as it conflicts
with livereload behavior