### PR TITLE
develop

### DIFF
--- a/commonjs/index.js
+++ b/commonjs/index.js
@@ -4,7 +4,6 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var path = _interopDefault(require('path'));
 var resolve = _interopDefault(require('rollup-plugin-node-resolve'));
 var babel = _interopDefault(require('rollup-plugin-babel'));
 var filesize = _interopDefault(require('rollup-plugin-filesize'));
@@ -169,7 +168,7 @@ function getCopyConfig(options) {
   const { entryDir, outputDir, assetsDir } = options;
   return {
     targets: [{
-      src: path.join(entryDir, 'index.html'),
+      src: `${entryDir}/index.html`,
       transform: injectScripts.bind(this, options),
       dest: outputDir
     }, {
@@ -254,7 +253,7 @@ function getBaseRollupConfig(options) {
   const parsedOptions = getSpecifiedOptionsOrDeaults(options);
   const { entryDir, entryFileName, outputDir, outputFileName } = parsedOptions;
   return [{
-    input: path.join(entryDir, `${entryFileName}.js`),
+    input: `${entryDir}/${entryFileName}.js`,
     output: {
       dir: outputDir,
       format: 'esm',
@@ -267,7 +266,7 @@ function getBaseRollupConfig(options) {
       babel(getPluginConfig('babel', parsedOptions))
     ]
   }, {
-    input: path.join(entryDir, `${entryFileName}.js`),
+    input: `${entryDir}/${entryFileName}.js`,
     output: {
       dir: outputDir,
       format: 'amd',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cap-rollup-config",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/plugins-config.mjs
+++ b/src/plugins-config.mjs
@@ -1,4 +1,3 @@
-import path from 'path';
 import { parse } from 'node-html-parser';
 import { minify } from 'terser';
 import { getSpecifiedOptionsOrDeaults } from './utils' ;
@@ -130,7 +129,7 @@ function getCopyConfig(options) {
   const { entryDir, outputDir, assetsDir } = options;
   return {
     targets: [{
-      src: path.join(entryDir, 'index.html'),
+      src: `${entryDir}/index.html`,
       transform: injectScripts.bind(this, options),
       dest: outputDir
     }, {

--- a/src/rollup-config.mjs
+++ b/src/rollup-config.mjs
@@ -1,4 +1,3 @@
-import path from 'path';
 import resolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 import filesize from 'rollup-plugin-filesize';
@@ -51,7 +50,7 @@ export function getBaseRollupConfig(options) {
   const parsedOptions = getSpecifiedOptionsOrDeaults(options);
   const { entryDir, entryFileName, outputDir, outputFileName } = parsedOptions;
   return [{
-    input: path.join(entryDir, `${entryFileName}.js`),
+    input: `${entryDir}/${entryFileName}.js`,
     output: {
       dir: outputDir,
       format: 'esm',
@@ -64,7 +63,7 @@ export function getBaseRollupConfig(options) {
       babel(getPluginConfig('babel', parsedOptions))
     ]
   }, {
-    input: path.join(entryDir, `${entryFileName}.js`),
+    input: `${entryDir}/${entryFileName}.js`,
     output: {
       dir: outputDir,
       format: 'amd',


### PR DESCRIPTION
* fix(*): use relative routes instead of path module

Path module uses backslash in windows and prevents rollup of
finding the files